### PR TITLE
Fix build error in the POSIX module

### DIFF
--- a/vendors/ti/boards/CC3220SF_LAUNCHXL/CMakeLists.txt
+++ b/vendors/ti/boards/CC3220SF_LAUNCHXL/CMakeLists.txt
@@ -179,12 +179,6 @@ target_include_directories(
         "$<IF:${AFR_IS_TESTING},${AFR_TESTS_DIR},${AFR_DEMOS_DIR}>/include"
         ${compiler_specific_include}
 )
-target_link_libraries(
-    AFR::kernel::mcu_port
-    INTERFACE
-        AFR::posix_headers
-        AFR::posix    
-)
 
 #POSIX
 afr_mcu_port(posix)
@@ -202,6 +196,7 @@ target_include_directories(
 target_link_libraries(
     AFR::posix::mcu_port
     INTERFACE AFR::freertos_plus_posix
+    AFR::posix
 )
 
 # Common I/O, currently only fully supported for GCC
@@ -234,11 +229,18 @@ target_sources(
     AFR::wifi::mcu_port
     INTERFACE "${portable_dir}/wifi/iot_wifi.c"
 )
+target_include_directories(
+    AFR::wifi::mcu_port BEFORE
+    INTERFACE
+      "${AFR_MODULES_ABSTRACTIONS_DIR}/posix/include"
+      "${AFR_MODULES_ABSTRACTIONS_DIR}/posix/include/FreeRTOS_POSIX"
+      "${AFR_MODULES_FREERTOS_PLUS_DIR}/standard/freertos_plus_posix/include"
+)
+
 # WiFi on TI requires POSIX types
 target_link_libraries(
     AFR::wifi::mcu_port
     INTERFACE
-        AFR::posix::mcu_port
         AFR::secure_sockets
 )
 

--- a/vendors/ti/boards/CC3220SF_LAUNCHXL/ports/posix/FreeRTOS_POSIX_portable.h
+++ b/vendors/ti/boards/CC3220SF_LAUNCHXL/ports/posix/FreeRTOS_POSIX_portable.h
@@ -31,7 +31,8 @@
 #ifndef _FREERTOS_POSIX_PORTABLE_H_
 #define _FREERTOS_POSIX_PORTABLE_H_
 
-/* This port uses the defaults in FreeRTOS_POSIX_portable_default.h, so this
- * file is empty. */
+#define posixconfigENABLE_CLOCKID_T              0
+#define posixconfigENABLE_MODE_T                 0
+#define posixconfigENABLE_TIMER_T                 0
 
 #endif /* _FREERTOS_POSIX_PORTABLE_H_ */


### PR DESCRIPTION
Fix build error in the POSIX module

Description
-----------
For some reason the kernel types were not being discovered when trying to compile POSIX. This makes some changes to the TI CMake to resolve those issues.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested my changes. No regression in existing tests.
- [ ] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.