### PR TITLE
Remove posix as a dependency on the test module. Disabled POSIX test

### DIFF
--- a/libraries/freertos_plus/standard/freertos_plus_posix/CMakeLists.txt
+++ b/libraries/freertos_plus/standard/freertos_plus_posix/CMakeLists.txt
@@ -34,20 +34,20 @@ afr_module_include_dirs(
 )
 
 # Test
-afr_test_module()
-afr_module_sources(
-    ${AFR_CURRENT_MODULE}
-    INTERFACE
-        "${test_dir}/iot_test_posix_clock.c"
-        "${test_dir}/iot_test_posix_mqueue.c"
-        "${test_dir}/iot_test_posix_pthread.c"
-        "${test_dir}/iot_test_posix_semaphore.c"
-        "${test_dir}/iot_test_posix_stress.c"
-        "${test_dir}/iot_test_posix_timer.c"
-        "${test_dir}/iot_test_posix_unistd.c"
-        "${test_dir}/iot_test_posix_utils.c"
-)
-afr_module_dependencies(
-    ${AFR_CURRENT_MODULE}
-    INTERFACE AFR::posix
-)
+#afr_test_module()
+#afr_module_sources(
+#    ${AFR_CURRENT_MODULE}
+#    INTERFACE
+#        "${test_dir}/iot_test_posix_clock.c"
+#        "${test_dir}/iot_test_posix_mqueue.c"
+#        "${test_dir}/iot_test_posix_pthread.c"
+#        "${test_dir}/iot_test_posix_semaphore.c"
+#        "${test_dir}/iot_test_posix_stress.c"
+#        "${test_dir}/iot_test_posix_timer.c"
+#        "${test_dir}/iot_test_posix_unistd.c"
+#        "${test_dir}/iot_test_posix_utils.c"
+#)
+#afr_module_dependencies(
+#    ${AFR_CURRENT_MODULE}
+#    INTERFACE AFR::posix
+#)

--- a/vendors/ti/boards/CC3220SF_LAUNCHXL/CMakeLists.txt
+++ b/vendors/ti/boards/CC3220SF_LAUNCHXL/CMakeLists.txt
@@ -311,11 +311,6 @@ if(AFR_ENABLE_DEMOS OR AFR_ENABLE_TESTS)
         PRIVATE
             "${sysconfig_out}"
             "${simplelink_common_src_dir}/utils/uart_term"
-            # We need to specify the POSIX header include directories 
-            # again as they do not seem to be set prior to this.
-            "${AFR_MODULES_ABSTRACTIONS_DIR}/posix/include"
-            "${AFR_MODULES_ABSTRACTIONS_DIR}/posix/include/FreeRTOS_POSIX"
-            "${AFR_MODULES_FREERTOS_PLUS_DIR}/standard/freertos_plus_posix/include"
     )
     target_link_libraries(
         ${exe_target}
@@ -323,7 +318,6 @@ if(AFR_ENABLE_DEMOS OR AFR_ENABLE_TESTS)
             AFR::common_io
             AFR::wifi
             AFR::utils
-            AFR::posix::mcu_port
             ${link_extra_flags}
             -T"${board_dir}/application_code/ti_code/cc32xxsf_freertos.lds"
     )


### PR DESCRIPTION
module for now.

<!--- Title -->

Description
-----------
<!--- Describe your changes in detail -->

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested my changes. No regression in existing tests.
- [ ] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.